### PR TITLE
Allow config file path to be supplied via CLI

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,10 +1,15 @@
 module Main where
 
 import           Control.Monad (void)
+import           System.Environment (getArgs)
 import           UnliftIO      (waitAnyCancel)
 
 import           MQTTD.Config
 import           MQTTD.Main
 
+configFilePath :: [String] -> String
+configFilePath [] = "mqttd.conf"
+configFilePath (path: _) = path
+
 main :: IO ()
-main = void . waitAnyCancel =<< runServer =<< parseConfFile "mqttd.conf"
+main = void . waitAnyCancel =<< runServer =<< parseConfFile . configFilePath =<< getArgs


### PR DESCRIPTION
I'm working on creating [a FreeBSD port for `mqttd`](https://github.com/wezm/freebsd-ports/commit/4f0736d22c2455426b2d890f0c27badb01534282) so I can install it through the package manager on my home automation machine. Typically config files for ports go in `/usr/local/etc` (but it would be a bit strange for this this to be pwd) so in this PR I've used my nascent Haskell skills to add support for passing the path to the config file on the command line. If the path is not supplied then the existing behaviour of looking in pwd for `mqttd.conf` is retained.